### PR TITLE
updating packer version to 1.2.2

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -114,9 +114,9 @@ sudo pip install 'azure==3.0.0'
 echo "================ Adding dopy 0.3.7 ======================="
 sudo pip install 'dopy==0.3.7'
 
-export PK_VERSION=1.2.3
+export PK_VERSION=1.2.2
 echo "================ Adding packer $PK_VERSION  ===================="
-export PK_FILE=packer_"$PK_VERSION"_linux_arm.zip
+export PK_FILE=packer_"$PK_VERSION"_linux_arm64.zip
 
 echo "Fetching packer"
 echo "-----------------------------------"


### PR DESCRIPTION

https://github.com/Shippable/pm/issues/10927

So as per the link [here](https://releases.hashicorp.com/packer/1.2.3/) for packer 1.2.3 they have not released this version for arm64. They do support arm64 for packer 1.2.2 see this [link](https://releases.hashicorp.com/packer/1.2.2/) for reference. So we should keep packer version to existing v1.2.2 in case of arm64.