### PR TITLE
Updating supported version for  packer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -113,9 +113,9 @@ sudo pip install 'azure==3.0.0'
 echo "================ Adding dopy 0.3.7 ======================="
 sudo pip install 'dopy==0.3.7'
 
-export PK_VERSION=1.2.5
+export PK_VERSION=1.2.2
 echo "================ Adding packer $PK_VERSION  ===================="
-export PK_FILE=packer_"$PK_VERSION"_linux_arm.zip
+export PK_FILE=packer_"$PK_VERSION"_linux_arm64.zip
 
 echo "Fetching packer"
 echo "-----------------------------------"


### PR DESCRIPTION
Rolling back to previous [version](https://packages.debian.org/sid/arm64/packer/filelist) because its falling in test cases  https://rcapp.shippable.com/github/Ranjansingh41/jobs/aarch64_u16/builds/5b7e9241625a080600b6430c/console 
https://github.com/Shippable/pm/issues/11288
